### PR TITLE
3 draw plane

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,5 +11,6 @@
     <p>Canvas failed to load</p>
   </canvas>
   <script src="main.bundle.js"></script>
+  <script src="lib/javascripts/scripts.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8">
   <title>1942</title>
-  <link href="lib/main.css" type="text/css" rel="stylesheet" />
+  <link href="lib/stylesheets/main.css" type="text/css" rel="stylesheet" />
 </head>
 <body>
   <p>1942</p>
-  <canvas id="nineteenfortytwo" height="500" width="700" class="center">
+  <canvas id="nineteenfortytwo" height="500" width="700">
     <p>Canvas failed to load</p>
   </canvas>
   <script src="main.bundle.js"></script>

--- a/lib/javascripts/scripts.js
+++ b/lib/javascripts/scripts.js
@@ -1,0 +1,33 @@
+var canvas = document.getElementById('nineteenfortytwo');
+var context = canvas.getContext('2d');
+
+var x = 30;
+var y = 10;
+var width = 8;
+var height = 25;
+var wingspan = 52;
+var tailspan = 16;
+var xMid = x + (width/2);
+context.fillStyle="red";
+// fuselage
+context.fillRect(x, y, width, height);
+// wings
+context.moveTo(xMid - (wingspan/2), 23);
+context.lineTo(xMid, 15);
+context.lineTo(xMid + (wingspan/2), 23);
+context.fill();
+// nose
+context.moveTo(x, y);
+context.lineTo(xMid, y - 5);
+context.lineTo(x + width, y);
+context.fill();
+// fuselage-tail connector
+context.moveTo(x, y + height);
+context.lineTo(xMid, y + height + 5);
+context.lineTo(x + width, y + height);
+context.fill();
+// tail
+context.moveTo(xMid - (tailspan/2), 42);
+context.lineTo(xMid, 35);
+context.lineTo(xMid + (tailspan/2), 42);
+context.fill();

--- a/lib/main.css
+++ b/lib/main.css
@@ -1,3 +1,0 @@
-#nineteenfortytwo {
-    background-color: blue;
-}

--- a/lib/stylesheets/main.css
+++ b/lib/stylesheets/main.css
@@ -1,0 +1,3 @@
+#nineteenfortytwo {
+    background-color: CadetBlue;
+}


### PR DESCRIPTION
This PR does a couple of things:

1) introduces the new plane drawing in a new `scripts.js` (attached, zoomed in but with 1942 included for scale)
<img width="266" alt="screen shot 2016-07-05 at 8 20 49 pm" src="https://cloud.githubusercontent.com/assets/13606384/16605633/06b001ac-42ee-11e6-897c-cd123bb2acf4.png">

2) creates the lib/stylesheets and lib/javascripts structure we were talking about
3) changes the canvas background color to cadetblue

I did the background color at the same time as drawing plane because it was hard enough to look at that red color on the plane without the really bright blue background. We'll probably need to pick a better red for the plane, but I thought we could discuss the whole color scheme at once.

closes #3 
closes #17 
