### PR TITLE
Make fillLine border arguments less fragile

### DIFF
--- a/lib/javascripts/border.js
+++ b/lib/javascripts/border.js
@@ -6,22 +6,22 @@ class Border {
 Border.prototype.rectangle = function(){
   this.border = [];
   // fill plane fuselage with coordinates from top left to top right
-  fillLine(this.width + 1,this,this.x,this.y,2,"horiz");
+  fillLine({length: this.width + 1,object: this,xValue: this.x,yValue: this.y,posValue: 2,direction: "horiz"});
   // fill plane fuselage with coordinates from top right to bottom right
-  fillLine(this.height,this,this.x + this.width,this.y + 1,2,"vert");
+  fillLine({length: this.height,object: this,xValue: this.x + this.width,yValue: this.y + 1,posValue: 2,direction: "vert"});
   // fill plane fuselage with coordinates from bottom right to bottom left
-  fillLine(this.width,this,this.x + this.width - 1,this.y + this.height,-2,"horiz");
+  fillLine({length: this.width,object: this,xValue: this.x + this.width - 1,yValue: this.y + this.height,posValue: -2,direction: "horiz"});
   // fill plane fuselage with coordinates from bottom right to top right
-  fillLine(this.height - 1,this,this.x,this.y + this.height - 1,-2,"vert");
+  fillLine({length: this.height - 1,object: this,xValue: this.x,yValue: this.y + this.height - 1,posValue: -2,direction: "vert"});
 };
 
-function fillLine(length,object,xValue,yValue,posValue,direction) {
-  for (let i = 0; i < length; i = i + 2) {
-    object.border.push([xValue, yValue]);
-    if (direction === "horiz") {
-      xValue = xValue + posValue;
-    } else if (direction === "vert") {
-      yValue = yValue + posValue;
+function fillLine(values) {
+  for (let i = 0; i < values.length; i = i + 2) {
+    values.object.border.push([values.xValue, values.yValue]);
+    if (values.direction === "horiz") {
+      values.xValue = values.xValue + values.posValue;
+    } else if (values.direction === "vert") {
+      values.yValue = values.yValue + values.posValue;
     }
   }
 }


### PR DESCRIPTION
This made the fillLine function within the border class less fragile by making it take a hash instead of receiving 5 million arguments.
- At some point we might want to add some of these
  attributes to the plane classes so that we don't 
  need to pass as many arguments along

I would start at the rectangle prototype which calls this function

To test this:
- run the program `npm start` 
- visit `http://localhost:8080/webpack-dev-server/`
- press enter at the start screen

if it doesnt work you should get an error within the console and the plane shouldn't render at the bottom of the canvas. If the planes there and there is no error it good.

This fillLine function adds [x,y] pairs to an array for collision detection in a straight line.

![taco](http://i.giphy.com/vKmHoLAQSKKhW.gif)
closes #68 

@GKhalsa
@martensonbj, @joshuajhun, @rrgayhart
